### PR TITLE
Shorthand formatting step

### DIFF
--- a/packages/guesstimator/formatter/formatters/DistributionTextUpTo.js
+++ b/packages/guesstimator/formatter/formatters/DistributionTextUpTo.js
@@ -1,6 +1,6 @@
-import {regexBasedFormatter, rangeRegex} from './lib'
+import {regexBasedFormatter, rangeRegex, SeparatorsDistributionUpTo} from './lib'
 
 export const item = {
   formatterName: 'DISTRIBUTION_NORMAL_TEXT_UPTO',
-  ...regexBasedFormatter(rangeRegex(/to|\.\.|->|:/)),
+  ...regexBasedFormatter(rangeRegex(SeparatorsDistributionUpTo)),
 }

--- a/packages/guesstimator/formatter/formatters/Function.js
+++ b/packages/guesstimator/formatter/formatters/Function.js
@@ -1,8 +1,15 @@
 import _ from "lodash";
+import {shorthandIntoLognormalFormattingStep} from './lib'
+
 //FIXME
+
+// The function: shorthandIntoLognormalFormattingStep
+// transforms strings like "=mm(normal(10,5), 1 to 100))
+// into strings like "=mm(normal(10,5), lognormal(50.1, 1.4))
+
 export const item = {
   formatterName: 'FUNCTION',
   matches({text}) { return !!text && text.startsWith('=') },
   error({text}) { return !_.isEmpty(text.slice(1)) ? {} : {type: 1, subType: 2}},
-  format({text}) { return {guesstimateType: 'FUNCTION', text: text.slice(1)} },
+  format({text}) { return {guesstimateType: 'FUNCTION', text: (shorthandIntoLognormalFormattingStep(text)).slice(1)} },
 }

--- a/packages/guesstimator/formatter/formatters/Function.js
+++ b/packages/guesstimator/formatter/formatters/Function.js
@@ -1,12 +1,6 @@
 import _ from "lodash";
 import {shorthandIntoLognormalFormattingStep} from './lib'
 
-//FIXME
-
-// The function: shorthandIntoLognormalFormattingStep
-// transforms strings like "=mm(normal(10,5), 1 to 100))
-// into strings like "=mm(normal(10,5), lognormal(50.1, 1.4))
-
 export const item = {
   formatterName: 'FUNCTION',
   matches({text}) { return !!text && text.startsWith('=') },

--- a/packages/guesstimator/formatter/formatters/lib.js
+++ b/packages/guesstimator/formatter/formatters/lib.js
@@ -71,8 +71,9 @@ export function shorthandIntoLognormalFormattingStep(text){
     
         p1 = Number(p1)
         p2 = Number(p2)
-        let logHigh = math.log(p1)
-        let logLow = math.log(p2)
+        
+        let logLow = math.log(p1)
+        let logHigh = math.log(p2)
 
         let mean = math.mean(p1,p2)
         let stdev = (logHigh-logLow) / (2*1.645)

--- a/packages/guesstimator/formatter/formatters/lib.js
+++ b/packages/guesstimator/formatter/formatters/lib.js
@@ -89,7 +89,7 @@ export function shorthandIntoLognormalFormattingStep(text){
 
     let regNumberToNumber= new RegExp("([0-9]+) to ([0-9]+)", "g");
     
-    return text.replace(regNumberToNumber, shorthandIntoLognormalReplacerStep);
+    return text.replace(regNumberToNumber, shorthandIntoLognormalReplacer);
 
 }
 

--- a/packages/guesstimator/formatter/formatters/lib.js
+++ b/packages/guesstimator/formatter/formatters/lib.js
@@ -1,5 +1,6 @@
 import _ from "lodash";
 import math from 'mathjs';  
+import {distributionUpToIntoLognormal} from "../../lib/distributionMath.js";
 
 const SUFFIXES = {
   '%': -2,
@@ -81,13 +82,7 @@ export function shorthandIntoLognormalFormattingStep(text){
         let low = arrayLowHigh[0]
         let high= arrayLowHigh[1]
 
-        let logLow = math.log(low)
-        let logHigh = math.log(high)
-
-        let mean = (math.mean(low,high)).toFixed(3)
-        let stdev = ((logHigh-logLow) / (2*1.645)).toFixed(3)
-
-        return `lognormal(${mean}, ${stdev})`
+        return distributionUpToIntoLognormal(low, high)
 
     } 
     

--- a/packages/guesstimator/formatter/formatters/lib.js
+++ b/packages/guesstimator/formatter/formatters/lib.js
@@ -31,8 +31,7 @@ const NUMBER_REGEX = new RegExp(`(-?${or([INTEGER_REGEX, DECIMAL_REGEX]).source}
 export const POINT_REGEX = padded([NUMBER_REGEX])
 export const rangeRegex = (sep, left, right) => padded([left, NUMBER_REGEX, sep, NUMBER_REGEX, right])
 
-rangeRegexIndividualDistributionTextUpTo = rangeRegex(/to|\.\.|->|:/)
-export rangeRegexIndividualDistributionTextUpTo
+export const SeparatorsDistributionUpTo = /to|\.\.|->|:/
 
 const getMult = suffix => Math.pow(10,SUFFIXES[suffix])
 const parseNumber = (num, suffix) => parseFloat(num.replace(',', '')) * (!!suffix ? getMult(suffix) : 1)
@@ -73,10 +72,11 @@ export function regexBasedFormatter(re, guesstimateTypeFn = getGuesstimateType, 
 // into strings like "=mm(normal(10,5), lognormal(50.1, 1.4))
 
 export function shorthandIntoLognormalFormattingStep(text){
-        
+  
     function shorthandIntoLognormalReplacer(string){
-    
-        let arrayLowHigh = getNumbers(string, rangeRegexIndividualDistributionTextUpTo)
+        
+        let rangeRegexIndividual = rangeRegex(SeparatorsDistributionUpTo)
+        let arrayLowHigh = getNumbers(string, rangeRegexIndividual)
       
         let low = arrayLowHigh[0]
         let high= arrayLowHigh[1]
@@ -92,7 +92,7 @@ export function shorthandIntoLognormalFormattingStep(text){
     } 
     
     let rangeRegexMultiple = (sep, left, right) => spaceSep([left, NUMBER_REGEX, sep, NUMBER_REGEX, right])
-    shorthandIntoLognormalRegex= new RegExp(rangeRegexMultiple(/to|\.\.|->|:/), "g")
+    let shorthandIntoLognormalRegex= new RegExp(rangeRegexMultiple(SeparatorsDistributionUpTo), "g")
   
     return text.replace(shorthandIntoLognormalRegex, shorthandIntoLognormalReplacer)
 

--- a/packages/guesstimator/formatter/formatters/lib.js
+++ b/packages/guesstimator/formatter/formatters/lib.js
@@ -1,4 +1,6 @@
 import _ from "lodash";
+import math from 'mathjs';  
+
 const SUFFIXES = {
   '%': -2,
   'K': 3,

--- a/packages/guesstimator/formatter/formatters/lib.js
+++ b/packages/guesstimator/formatter/formatters/lib.js
@@ -58,18 +58,9 @@ export function regexBasedFormatter(re, guesstimateTypeFn = getGuesstimateType, 
   }
 }
 
-
-
-
-
 // The function: shorthandIntoLognormalFormattingStep 
-// is used in foretold/packages/guesstimator/formatter/formatters/Function.js
-// In order to be able to format inputs like "1 to 100" when inside a multimodal, like "=mm(normal(10,5), 1 to 100))".
-
-// The function: shorthandIntoLognormalReplacer
-// is inside shorthandIntoLognormalFormatting. This might be marginally slower, but it makes clear that it is not used by any other function.
-// Note: "a string".replace can take a function, rather than a string, as its second argument.
-// See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#Specifying_a_function_as_a_parameter
+// transforms strings like "=mm(normal(10,5), 1 to 100))
+// into strings like "=mm(normal(10,5), lognormal(50.1, 1.4))
 
 export function shorthandIntoLognormalFormattingStep(text){
         

--- a/packages/guesstimator/formatter/formatters/lib.js
+++ b/packages/guesstimator/formatter/formatters/lib.js
@@ -59,7 +59,8 @@ export function regexBasedFormatter(re, guesstimateTypeFn = getGuesstimateType, 
 }
 
 // The function: shorthandIntoLognormalFormattingStep 
-// transforms strings like "=mm(normal(10,5), 1 to 100))
+// is used to format inputs like "1 to 100" when inside a multimodal.
+// It transforms strings like "=mm(normal(10,5), 1 to 100))
 // into strings like "=mm(normal(10,5), lognormal(50.1, 1.4))
 
 export function shorthandIntoLognormalFormattingStep(text){

--- a/packages/guesstimator/formatter/formatters/lib.js
+++ b/packages/guesstimator/formatter/formatters/lib.js
@@ -75,8 +75,8 @@ export function shorthandIntoLognormalFormattingStep(text){
         let logLow = math.log(p1)
         let logHigh = math.log(p2)
 
-        let mean = math.mean(p1,p2)
-        let stdev = (logHigh-logLow) / (2*1.645)
+        let mean = (math.mean(p1,p2)).toFixed(3)
+        let stdev = ((logHigh-logLow) / (2*1.645)).toFixed(3)
         
         return `lognormal(${mean}, ${stdev})`
 

--- a/packages/guesstimator/formatter/formatters/lib.js
+++ b/packages/guesstimator/formatter/formatters/lib.js
@@ -57,3 +57,39 @@ export function regexBasedFormatter(re, guesstimateTypeFn = getGuesstimateType, 
     _numbers(text) { return _.chunk(text.match(re).slice(1), 2).map(([num, suffix]) => parseNumber(num, suffix)) },
   }
 }
+
+
+
+
+
+// The function: shorthandIntoLognormalFormattingStep 
+// is used in foretold/packages/guesstimator/formatter/formatters/Function.js
+// In order to be able to format inputs like "1 to 100" when inside a multimodal, like "=mm(normal(10,5), 1 to 100))".
+
+// The function: shorthandIntoLognormalReplacer
+// is inside shorthandIntoLognormalFormatting. This might be marginally slower, but it makes clear that it is not used by any other function.
+// Note: "a string".replace can take a function, rather than a string, as its second argument.
+// See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#Specifying_a_function_as_a_parameter
+
+export function shorthandIntoLognormalFormattingStep(text){
+        
+    function shorthandIntoLognormalReplacer(match, p1, p2){
+    
+        p1 = Number(p1)
+        p2 = Number(p2)
+        let logHigh = math.log(p1)
+        let logLow = math.log(p2)
+
+        let mean = math.mean(p1,p2)
+        let stdev = (logHigh-logLow) / (2*1.645)
+        
+        return `lognormal(${mean}, ${stdev})`
+
+    } 
+
+    let regNumberToNumber= new RegExp("([0-9]+) to ([0-9]+)", "g");
+    
+    return text.replace(regNumberToNumber, shorthandIntoLognormalReplacerStep);
+
+}
+

--- a/packages/guesstimator/formatter/formatters/tests/lib-test.js
+++ b/packages/guesstimator/formatter/formatters/tests/lib-test.js
@@ -1,0 +1,20 @@
+import {shorthandIntoLognormalFormattingStep} from '../lib.js'
+
+describe('shorthandIntoLognormalFormattingStep', () => {
+
+  describe('Behavior:', () => {
+    const examples = [
+      ['1 to 10', 'lognormal(5.500, 0.700)'],
+      ['1K to 10K', 'lognormal(5500.000, 0.700)' ],
+      ['-1 to 10', "[unknown]"],
+      ['1-10', 'lognormal(5.500, 0.700)'],
+      ['1:10', 'lognormal(5.500, 0.700)'],
+    ]
+
+    examples.map(e => () => {
+      it(`shorthandIntoLognormalFormattingStep takes ${e[0]} and converts it to ${shorthandIntoLognormalFormattingStep(e[0])}. It should convert it to ${e[1]}`, () => {
+        expect(shorthandIntoLognormalFormattingStep(e[0])).to.equal(e[1])
+      })
+    }).map(e => e())
+  });
+})

--- a/packages/guesstimator/formatter/formatters/tests/lib-test.js
+++ b/packages/guesstimator/formatter/formatters/tests/lib-test.js
@@ -7,7 +7,7 @@ describe('shorthandIntoLognormalFormattingStep', () => {
       ['1 to 10', 'lognormal(5.500, 0.700)'],
       ['1K to 10K', 'lognormal(5500.000, 0.700)' ],
       ['-1 to 10', "[unknown]"],
-      ['1-10', 'lognormal(5.500, 0.700)'],
+      ['1->10', 'lognormal(5.500, 0.700)'],
       ['1:10', 'lognormal(5.500, 0.700)'],
     ]
 

--- a/packages/guesstimator/formatter/formatters/tests/lib-test.js
+++ b/packages/guesstimator/formatter/formatters/tests/lib-test.js
@@ -4,11 +4,11 @@ describe('shorthandIntoLognormalFormattingStep', () => {
 
   describe('Behavior:', () => {
     const examplesShort = [
-      ['1 to 10', 'lognormal(5.500, 0.700)'],
-      ['1K to 10K', 'lognormal(5500.000, 0.700)' ],
+      ['1 to 10', 'lognormal(1.151, 0.700)'],
+      ['1K to 10K', 'lognormal(9.210, 0.700)' ],
       ['-1 to 10', "[unknown]"],
-      ['1->10', 'lognormal(5.500, 0.700)'],
-      ['1:10', 'lognormal(5.500, 0.700)'],
+      ['1->10', 'lognormal(1.151, 0.700)'],
+      ['1:10', 'lognormal(1.151, 0.700)'],
     ]
 
     examplesShort.map(e => () => {
@@ -18,11 +18,11 @@ describe('shorthandIntoLognormalFormattingStep', () => {
     }).map(e => e())
 
     const examplesInContext = [
-      ['=mm(1 to 10, normal(1,1),[.1,.3])', '=mm(lognormal(5.500, 0.700), normal(1,1),[.1,.3])'],
-      ['=mm(1K to 10K, normal(1,1),[.1,.3])', '=mm(lognormal(5500.000, 0.700), normal(1,1),[.1,.3])' ],
+      ['=mm(1 to 10, normal(1,1),[.1,.3])', '=mm(lognormal(1.151, 0.700), normal(1,1),[.1,.3])'],
+      ['=mm(1K to 10K, normal(1,1),[.1,.3])', '=mm(lognormal9.210.000, 0.700), normal(1,1),[.1,.3])' ],
       ['=mm(-1 to 10, normal(1,1),[.1,.3])', "[unknown]"],
-      ['=mm(1->10, normal(1,1),[.1,.3])', '=mm(lognormal(5.500, 0.700), normal(1,1),[.1,.3])'],
-      ['=mm(1:10, normal(1,1),[.1,.3])', '=mm(lognormal(5.500, 0.700), normal(1,1),[.1,.3])'],
+      ['=mm(1->10, normal(1,1),[.1,.3])', '=mm(lognormal(1.151, 0.700), normal(1,1),[.1,.3])'],
+      ['=mm(1:10, normal(1,1),[.1,.3])', '=mm(lognormal(1.151, 0.700), normal(1,1),[.1,.3])'],
     ]
 
     examplesInContext.map(e => () => {

--- a/packages/guesstimator/formatter/formatters/tests/lib-test.js
+++ b/packages/guesstimator/formatter/formatters/tests/lib-test.js
@@ -31,7 +31,5 @@ describe('shorthandIntoLognormalFormattingStep', () => {
       })
     }).map(e => e())
 
-    examplesWhichBreakTheCurrentSystem
-
   });
 })

--- a/packages/guesstimator/formatter/formatters/tests/lib-test.js
+++ b/packages/guesstimator/formatter/formatters/tests/lib-test.js
@@ -3,7 +3,7 @@ import {shorthandIntoLognormalFormattingStep} from '../lib.js'
 describe('shorthandIntoLognormalFormattingStep', () => {
 
   describe('Behavior:', () => {
-    const examples = [
+    const examplesShort = [
       ['1 to 10', 'lognormal(5.500, 0.700)'],
       ['1K to 10K', 'lognormal(5500.000, 0.700)' ],
       ['-1 to 10', "[unknown]"],
@@ -11,10 +11,27 @@ describe('shorthandIntoLognormalFormattingStep', () => {
       ['1:10', 'lognormal(5.500, 0.700)'],
     ]
 
-    examples.map(e => () => {
+    examplesShort.map(e => () => {
       it(`shorthandIntoLognormalFormattingStep takes ${e[0]} and converts it to ${shorthandIntoLognormalFormattingStep(e[0])}. It should convert it to ${e[1]}`, () => {
         expect(shorthandIntoLognormalFormattingStep(e[0])).to.equal(e[1])
       })
     }).map(e => e())
+
+    const examplesInContext = [
+      ['=mm(1 to 10, normal(1,1),[.1,.3])', '=mm(lognormal(5.500, 0.700), normal(1,1),[.1,.3])'],
+      ['=mm(1K to 10K, normal(1,1),[.1,.3])', '=mm(lognormal(5500.000, 0.700), normal(1,1),[.1,.3])' ],
+      ['=mm(-1 to 10, normal(1,1),[.1,.3])', "[unknown]"],
+      ['=mm(1->10, normal(1,1),[.1,.3])', '=mm(lognormal(5.500, 0.700), normal(1,1),[.1,.3])'],
+      ['=mm(1:10, normal(1,1),[.1,.3])', '=mm(lognormal(5.500, 0.700), normal(1,1),[.1,.3])'],
+    ]
+
+    examplesInContext.map(e => () => {
+      it(`shorthandIntoLognormalFormattingStep takes ${e[0]} and converts it to ${shorthandIntoLognormalFormattingStep(e[0])}. It should convert it to ${e[1]}`, () => {
+        expect(shorthandIntoLognormalFormattingStep(e[0])).to.equal(e[1])
+      })
+    }).map(e => e())
+
+    examplesWhichBreakTheCurrentSystem
+
   });
 })

--- a/packages/guesstimator/lib/distributionMath.js
+++ b/packages/guesstimator/lib/distributionMath.js
@@ -1,7 +1,5 @@
 import math from 'mathjs'
 
-
-
 // The function: distributionUpToIntoLognormal
 // assumes a centered 90% confidence interval, e.g. the left endpoint
 // marks 0.05% on the CDF, the right 0.95%.

--- a/packages/guesstimator/lib/distributionMath.js
+++ b/packages/guesstimator/lib/distributionMath.js
@@ -1,0 +1,12 @@
+import math from 'mathjs'
+
+export function distributionUpToIntoLognormal(low, high){
+
+    let logHigh = math.log(high)
+    let logLow = math.log(low)
+
+    let mean = (math.mean(logHigh, logLow)).toFixed(3)
+    let stdev = ((logHigh-logLow) / (2*1.645)).toFixed(3)
+
+    return `lognormal(${mean},${stdev})`
+}

--- a/packages/guesstimator/lib/distributionMath.js
+++ b/packages/guesstimator/lib/distributionMath.js
@@ -1,5 +1,11 @@
 import math from 'mathjs'
 
+
+
+// The function: distributionUpToIntoLognormal
+// assumes a centered 90% confidence interval, e.g. the left endpoint
+// marks 0.05% on the CDF, the right 0.95%.
+
 export function distributionUpToIntoLognormal(low, high){
 
     let logHigh = math.log(high)

--- a/packages/guesstimator/lib/distributionMath.js
+++ b/packages/guesstimator/lib/distributionMath.js
@@ -9,8 +9,8 @@ export function distributionUpToIntoLognormal(low, high){
     let logHigh = math.log(high)
     let logLow = math.log(low)
 
-    let mean = (math.mean(logHigh, logLow)).toFixed(3)
-    let stdev = ((logHigh-logLow) / (2*1.645)).toFixed(3)
+    let mean = (math.mean(logHigh, logLow))
+    let stdev = ((logHigh-logLow) / (2*1.645))
 
     return `lognormal(${mean},${stdev})`
 }

--- a/packages/guesstimator/samplers/DistributionLognormal.js
+++ b/packages/guesstimator/samplers/DistributionLognormal.js
@@ -1,16 +1,11 @@
 import math from 'mathjs'
 import {simulate} from './Simulator'
+import {distributionUpToIntoLognormal} from '../lib/distributionMath.js'
 
 export var Sampler = {
   sample({params: [low, high]}, n, _1) {
     // This assumes a centered 90% confidence interval, e.g. the left endpoint
     // marks 0.05% on the CDF, the right 0.95%.
-    const logHigh = math.log(high)
-    const logLow = math.log(low)
-
-    const mean = math.mean(logHigh, logLow)
-    const stdev = (logHigh-logLow) / (2*1.645)
-
-    return simulate(`lognormal(${mean},${stdev})`, [], n)
+    return simulate(distributionUpToIntoLognormal(low, high), [], n)
   }
 }

--- a/packages/guesstimator/samplers/DistributionLognormal.js
+++ b/packages/guesstimator/samplers/DistributionLognormal.js
@@ -4,8 +4,6 @@ import {distributionUpToIntoLognormal} from '../lib/distributionMath.js'
 
 export var Sampler = {
   sample({params: [low, high]}, n, _1) {
-    // This assumes a centered 90% confidence interval, e.g. the left endpoint
-    // marks 0.05% on the CDF, the right 0.95%.
     return simulate(distributionUpToIntoLognormal(low, high), [], n)
   }
 }


### PR DESCRIPTION
Addressed the cosmetic changes:
1. PRs as a whole unit
2. Write the comments above the functions
3. Renamed NumberToNumberIntoLognormal to shorthandIntoLognormalFormattingStep, which might be more to your liking.

Did not address:
4. Similarities to DistributionLognormal.js. This sounds like something which would take some more thought.
6. Tests. This seems important. Will do next.

Re 5, Special cases. I did some testing:
5a. This doesn't address other syntaxes, like "3-10" (or "3 - 10", or whitespaces). Which other syntaxes are there? I haven't seen people use them in foretold, but I'm happy to add them. Also, the input "3-10" doesn't produce any distribution in foretold right now.
5b. I am uncertain about whether this addresses things like "3K to 4K". Right now, foretold.io doesn't accept =lognormal(3.5K, 10) as an input, so it probably doesn't.
5c. This doesn't handle cases where the low number is 0 or less, like, "-3K to 3K". Right now, "=lognormal(-10, 2)" also breaks foretold. In fact, it is accepted as an input, but the distribution produced is a different one. Same with the inputs: "-3K to 3K", "-10 to 1".

tl;dr: The special cases are mostly not supported on foretold right now, or break it. I haven't seen people use them.