### PR TITLE
Minor Fixes

### DIFF
--- a/packages/client/graphql_schema.json
+++ b/packages/client/graphql_schema.json
@@ -324,6 +324,24 @@
                   "defaultValue": null
                 },
                 {
+                  "name": "measurableIds",
+                  "description": null,
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "SCALAR",
+                        "name": "String",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
                   "name": "creatorId",
                   "description": null,
                   "type": {

--- a/packages/client/src/Markdown.re
+++ b/packages/client/src/Markdown.re
@@ -57,7 +57,7 @@ module Styles = {
 type renderers = {. "code": code => ReasonReact.reactElement};
 
 // switch (code##language, , code##value) {
-let foretoldJsRenderers = (channelId): renderers => {
+let foretoldJsRenderers = {
   "code": (code: code) => {
     switch (
       Js.Nullable.toOption(code##language),
@@ -75,7 +75,7 @@ let foretoldJsRenderers = (channelId): renderers => {
               width(`percent(100.)),
             ])
           )>
-          <DashboardTableC channelId tableJson=json />
+          <DashboardTableC tableJson=json />
         </div>
       | None => "Invalid Json. Check a formatting tool." |> Utils.ste
       }
@@ -88,13 +88,10 @@ let foretoldJsRenderers = (channelId): renderers => {
 };
 
 [@react.component]
-let make = (~source, ~supportForetoldJs=false, ~channelId=?) => {
-  switch (supportForetoldJs, channelId) {
-  | (true, Some(channelId)) =>
-    <div className=Styles.all>
-      <ReactMarkdown source renderers={foretoldJsRenderers(channelId)} />
-    </div>
-  | (true, None) => <ReactMarkdown source />
-  | (false, _) => <ReactMarkdown source />
-  };
+let make = (~source, ~supportForetoldJs=false) => {
+  supportForetoldJs
+    ? <div className=Styles.all>
+        <ReactMarkdown source renderers=foretoldJsRenderers />
+      </div>
+    : <ReactMarkdown source />;
 };

--- a/packages/client/src/graphql/measurables/MeasurablesGet.re
+++ b/packages/client/src/graphql/measurables/MeasurablesGet.re
@@ -86,7 +86,8 @@ let toMeasurable = m => {
 module Query = [%graphql
   {|
     query getMeasurables (
-        $states: [measurableState]!
+        $measurableIds: [String!]
+        $states: [measurableState!]
         $channelId: String
         $seriesId: String
         $creatorId: String
@@ -96,6 +97,7 @@ module Query = [%graphql
         $before: Cursor
     ) {
         measurables (
+            measurableIds: $measurableIds
             states: $states
             channelId: $channelId
             seriesId: $seriesId
@@ -209,15 +211,23 @@ let unpackEdges = a =>
 
 let queryDirection =
     (
-      ~states,
+      ~states=?,
       ~seriesId=?,
       ~channelId=?,
       ~creatorId=?,
+      ~measurableIds,
       ~pageLimit,
       ~direction,
       (),
     ) => {
-  let fn = Query.make(~seriesId?, ~channelId?, ~creatorId?, ~states);
+  let fn =
+    Query.make(
+      ~seriesId?,
+      ~channelId?,
+      ~creatorId?,
+      ~measurableIds?,
+      ~states?,
+    );
   switch ((direction: Primary.Connection.direction)) {
   | None => fn(~first=pageLimit, ())
   | After(after) => fn(~first=pageLimit, ~after, ())
@@ -241,9 +251,10 @@ let component =
       ~creatorId=None,
       ~seriesId=None,
       ~channelId=None,
+      ~measurableIds=None,
+      ~states=None,
       ~pollInterval=?,
       ~pageLimit,
-      ~states,
       ~direction,
       ~innerComponentFn,
       (),
@@ -253,10 +264,11 @@ let component =
       ~channelId?,
       ~seriesId?,
       ~creatorId?,
+      ~states?,
+      ~measurableIds,
       ~pageLimit,
       ~direction,
-      ~states,
       (),
     );
-  componentMaker(~pollInterval=?pollInterval, query, innerComponentFn);
+  componentMaker(~pollInterval?, query, innerComponentFn);
 };

--- a/packages/client/src/lib/cdf-components/GuesstimateInput.js
+++ b/packages/client/src/lib/cdf-components/GuesstimateInput.js
@@ -9,7 +9,11 @@ import { Samples, Cdf } from "../../../../cdf";
  * @param {number} ratio
  * @return {string}
  */
-const minMaxRatio = (ratio) => {
+const minMaxRatio = (minValue, maxValue) => {
+  if (minValue === 0 || maxValue === 0){
+    return "SMALL"
+  }
+  const ratio = maxValue / minValue;
   if (ratio < 100000) {
     return "SMALL"
   } else if (ratio < 10000000) {
@@ -27,7 +31,7 @@ const ratioSize = samples => {
   samples.sort();
   const minValue = samples.getPercentile(2);
   const maxValue = samples.getPercentile(98);
-  return minMaxRatio(maxValue / minValue);
+  return minMaxRatio(minValue, maxValue);
 };
 
 /**

--- a/packages/client/src/lib/dashboardTable/Dashboard.re
+++ b/packages/client/src/lib/dashboardTable/Dashboard.re
@@ -10,7 +10,7 @@ module Styles = {
 };
 
 [@react.component]
-let make = (~channelId: string) => {
+let make = () => {
   let (text, setText) = React.useState(() => "");
 
   <SLayout isFluid=true>
@@ -22,7 +22,7 @@ let make = (~channelId: string) => {
           value=text
         />
       </div>
-      <Markdown source=text channelId supportForetoldJs=true />
+      <Markdown source=text supportForetoldJs=true />
     </FC.PageCard.Body>
   </SLayout>;
 };

--- a/packages/client/src/lib/dashboardTable/DashboardTable.re
+++ b/packages/client/src/lib/dashboardTable/DashboardTable.re
@@ -2,7 +2,8 @@
 
 type columnType =
   | String
-  | MeasurableId;
+  | MeasurableId
+  | MeasurementValue;
 
 module Column = {
   type t = {
@@ -18,6 +19,7 @@ module Column = {
 type cell =
   | String(string)
   | MeasurableId(string)
+  | MeasurementValue(MeasurementValue.t)
   | Empty;
 
 module Row = {
@@ -65,6 +67,7 @@ module Json = {
           columnType:
             switch (columnType) {
             | "MeasurableId" => MeasurableId
+            | "MeasurementValue" => MeasurementValue
             | _ => String
             },
         })
@@ -92,6 +95,17 @@ module Json = {
              |> Json.Decode.(optional(field(column.id, string)))
              |> E.O.fmap(r => String(r))
              |> E.O.default(Empty)
+           | MeasurementValue =>
+             switch (
+               json
+               |> Json.Decode.(
+                    optional(field(column.id, MeasurementValue.decode))
+                  )
+             ) {
+             | Some(Ok(r)) => MeasurementValue(r)
+             | Some(Error(_)) => Empty
+             | _ => Empty
+             }
            | MeasurableId =>
              json
              |> Json.Decode.(optional(field(column.id, string)))

--- a/packages/client/src/lib/dashboardTable/DashboardTableC.re
+++ b/packages/client/src/lib/dashboardTable/DashboardTableC.re
@@ -60,24 +60,24 @@ let tableJsonString = {| { "columns": [{"id":"1", "name": "Name", "columnType": 
 let tableJson: Js.Json.t = Json.parseOrRaise(tableJsonString);
 
 [@react.component]
-let make = (~channelId, ~tableJson=tableJson) => {
-  MeasurablesGet.component(
-    ~channelId=Some(channelId),
-    ~states=[|Some(`OPEN)|],
-    ~pageLimit=Js.Json.number(100 |> float_of_int),
-    ~direction=None,
-    ~pollInterval=20 * 1000,
-    ~innerComponentFn=
-      e =>
-        e
-        |> HttpResponse.fmap(
-             (r: Client.Primary.Connection.t(Client.Primary.Measurable.t)) =>
-             switch (DashboardTable.Json.decode(tableJson)) {
-             | Ok(table) => DashboardTableToTable.run(table, r.edges)
-             | Error(e) => e |> Utils.ste
-             }
-           )
-        |> HttpResponse.withReactDefaults,
-    (),
-  );
+let make = (~tableJson=tableJson) => {
+  switch (DashboardTable.Json.decode(tableJson)) {
+  | Ok(table) =>
+    MeasurablesGet.component(
+      ~measurableIds=Some(DashboardTable.Table.allMeasurableIds(table)),
+      ~pageLimit=Js.Json.number(500 |> float_of_int),
+      ~direction=None,
+      ~pollInterval=20 * 1000,
+      ~innerComponentFn=
+        e =>
+          e
+          |> HttpResponse.fmap(
+               (r: Client.Primary.Connection.t(Client.Primary.Measurable.t)) =>
+               DashboardTableToTable.run(table, r.edges)
+             )
+          |> HttpResponse.withReactDefaults,
+      (),
+    )
+  | Error(e) => e |> Utils.ste
+  };
 };

--- a/packages/client/src/lib/dashboardTable/DashboardTableC.re
+++ b/packages/client/src/lib/dashboardTable/DashboardTableC.re
@@ -14,6 +14,7 @@ module DashboardTableToTable = {
         (c: DashboardTable.Row.t) =>
           switch (Belt.Array.get(c, index)) {
           | Some(String(str)) => str |> Utils.ste
+          | Some(MeasurementValue(_)) => "MeasurementValue" |> Utils.ste
           | Some(MeasurableId(str)) =>
             measurables
             |> E.A.getBy(_, r => r.id == str)
@@ -35,7 +36,7 @@ module DashboardTableToTable = {
                   </div>
                 | None =>
                   <FC__Alert type_=`warning>
-                    {"Not loaded :(" |> Utils.ste}
+                    {"Not loaded" |> Utils.ste}
                   </FC__Alert>
                 }
             )

--- a/packages/client/src/pages/agents/AgentMeasurables.re
+++ b/packages/client/src/pages/agents/AgentMeasurables.re
@@ -9,7 +9,7 @@ module ReducerConfig = {
   let callFn = (creatorId: callFnParams) =>
     MeasurablesGet.component(
       ~creatorId=Some(creatorId),
-      ~states=[|Some(`OPEN)|],
+      ~states=Some([|`OPEN|]),
       (),
     );
 

--- a/packages/client/src/pages/measurables/MeasurableIndex__Logic.re
+++ b/packages/client/src/pages/measurables/MeasurableIndex__Logic.re
@@ -13,7 +13,7 @@ module ReducerConfig = {
   let callFn = (params: callFnParams) =>
     MeasurablesGet.component(
       ~channelId=Some(params.channelId),
-      ~states=params.states |> E.O.default([||]) |> Array.map(r => Some(r)),
+      ~states=Some(params.states |> E.O.default([||])),
       (),
     );
 

--- a/packages/client/src/pages/measurables/MeasurableNew.re
+++ b/packages/client/src/pages/measurables/MeasurableNew.re
@@ -33,7 +33,9 @@ let make = (~channelId) => {
         labelProperty: "",
         labelSubject: "",
         expectedResolutionDate:
-          MomentRe.momentNow() |> MeasurableForm.formatDate,
+          MomentRe.momentNow()
+          |> MomentRe.Moment.add(~duration=MomentRe.duration(1.0, `months))
+          |> MeasurableForm.formatDate,
         labelOnDate: MomentRe.momentNow() |> MeasurableForm.formatDate,
         resolutionEndpoint: "",
         showDescriptionDate: "FALSE",

--- a/packages/client/src/pages/notebooks/NotebookCreate.re
+++ b/packages/client/src/pages/notebooks/NotebookCreate.re
@@ -23,8 +23,7 @@ let make = (~channelId: string) => {
          onSubmit,
          notebook,
          ({send, state, getFieldState}) => {
-           let form =
-             NotebookForm.formFields(state, send, getFieldState, channelId);
+           let form = NotebookForm.formFields(state, send, getFieldState);
 
            let onSuccess = _ =>
              {Routing.Url.push(ChannelNotebooks(channelId))

--- a/packages/client/src/pages/notebooks/NotebookForm.re
+++ b/packages/client/src/pages/notebooks/NotebookForm.re
@@ -62,7 +62,7 @@ let withForm = (onSubmit, notebook: option(Types.notebook), innerComponentFn) =>
   |> E.React2.el;
 };
 
-let formFields = (state: Form.state, send, getFieldState, channelId) => {
+let formFields = (state: Form.state, send, getFieldState) => {
   let onSubmit = () => send(Form.Submit);
 
   let stateName = getFieldState(Form.Field(Name));
@@ -121,11 +121,7 @@ let formFields = (state: Form.state, send, getFieldState, channelId) => {
         </Antd.Form.Item>
       </Div>
       <Div flex={`num(1.)}>
-        <Markdown
-          source={state.values.body}
-          channelId
-          supportForetoldJs=true
-        />
+        <Markdown source={state.values.body} supportForetoldJs=true />
       </Div>
     </Div>
   </FC__PageCard.BodyPadding>;

--- a/packages/client/src/pages/notebooks/NotebookPage.re
+++ b/packages/client/src/pages/notebooks/NotebookPage.re
@@ -84,11 +84,7 @@ let make = (~channelId: string, ~notebookId: string) => {
                      style([marginTop(`em(2.0)), marginBottom(`em(2.0))])
                    )>
                    <NotebookHeader notebook />
-                   <Markdown
-                     source={notebook.body}
-                     supportForetoldJs=true
-                     channelId
-                   />
+                   <Markdown source={notebook.body} supportForetoldJs=true />
                  </div>
                | Details =>
                  <FC__PageCard.BodyPadding>

--- a/packages/client/src/pages/notebooks/NotebookUpdate.re
+++ b/packages/client/src/pages/notebooks/NotebookUpdate.re
@@ -20,13 +20,7 @@ let make = (~notebook: Types.notebook, ~onSuccess) => {
       onSubmit,
       Some(notebook),
       ({send, state, getFieldState}) => {
-        let form =
-          NotebookForm.formFields(
-            state,
-            send,
-            getFieldState,
-            notebook.channelId,
-          );
+        let form = NotebookForm.formFields(state, send, getFieldState);
 
         let onSuccess = e => {
           onSuccess(e);

--- a/packages/client/src/pages/series/SeriesShow.re
+++ b/packages/client/src/pages/series/SeriesShow.re
@@ -9,7 +9,7 @@ module Config = {
   let callFn = (seriesId: callFnParams) =>
     MeasurablesGet.component(
       ~seriesId=Some(seriesId),
-      ~states=[|Some(`OPEN)|],
+      ~states=Some([|`OPEN|]),
       (),
     );
 

--- a/packages/server/src/data/classes/filter.js
+++ b/packages/server/src/data/classes/filter.js
@@ -26,6 +26,7 @@ class Filter {
     const list = {
       id: (v) => _.isString(v) || utils.none(v),
       isArchived: (v) => _.isArray(v) || utils.none(v),
+      measurableIds: (v) => _.isArray(v) || utils.none(v),
       withinJoinedChannels: (v) => _.isObject(v) || utils.none(v),
       excludeChannelId: (v) => _.isString(v) || utils.none(v),
       notificationId: (v) => _.isString(v) || utils.none(v),

--- a/packages/server/src/graphql/resolvers/measurables.js
+++ b/packages/server/src/graphql/resolvers/measurables.js
@@ -44,6 +44,7 @@ async function all(root, args, context, info) {
   const filter = new Filter({
     channelId,
     withinJoinedChannels,
+    measurableIds: _.get(args, 'measurableIds', null),
     creatorId: _.get(args, 'creatorId', null),
     seriesId: _.get(args, 'seriesId', null),
     states: _.get(args, 'states', null),

--- a/packages/server/src/graphql/schema.js
+++ b/packages/server/src/graphql/schema.js
@@ -93,7 +93,7 @@ const schema = new graphql.GraphQLSchema({
         type: types.measurables.measurablesConnection,
         args: {
           ...types.common.connectionArguments,
-          measurableIds: { type: graphql.GraphQLList(graphql.GraphQLString) },
+          measurableIds: { type: graphql.GraphQLList(graphql.GraphQLNonNull(graphql.GraphQLString)) },
           creatorId: { type: graphql.GraphQLString },
           seriesId: { type: graphql.GraphQLString },
           channelId: { type: graphql.GraphQLString },

--- a/packages/server/src/graphql/schema.js
+++ b/packages/server/src/graphql/schema.js
@@ -93,6 +93,7 @@ const schema = new graphql.GraphQLSchema({
         type: types.measurables.measurablesConnection,
         args: {
           ...types.common.connectionArguments,
+          measurableIds: { type: graphql.GraphQLList(graphql.GraphQLString) },
           creatorId: { type: graphql.GraphQLString },
           seriesId: { type: graphql.GraphQLString },
           channelId: { type: graphql.GraphQLString },

--- a/packages/server/src/models-abstract/model-postgres.js
+++ b/packages/server/src/models-abstract/model-postgres.js
@@ -358,6 +358,14 @@ class ModelPostgres extends Model {
       });
     }
 
+    if (!!filter.measurableIds) {
+      where[this.and].push({
+        id: {
+          [this.in]: filter.measurableIds,
+        }
+      });
+    }
+
     if (!!filter.userId) {
       where[this.and].push({
         userId: filter.userId,

--- a/packages/server/src/models/measurable.js
+++ b/packages/server/src/models/measurable.js
@@ -2,6 +2,7 @@ const Sequelize = require('sequelize');
 
 const { MEASURABLE_STATE } = require('../enums/measurable-state');
 const { MEASURABLE_VALUE_TYPE } = require('../enums/measurable-value-type');
+const moment = require('moment');
 
 module.exports = (sequelize, DataTypes) => {
   const Measurable = sequelize.define('Measurable', {
@@ -75,9 +76,12 @@ module.exports = (sequelize, DataTypes) => {
       type: DataTypes.TEXT,
       allowNull: true,
     },
+
+    // We default to having questions resolve 1 month after they are created.
     expectedResolutionDate: {
       allowNull: true,
       type: DataTypes.DATE,
+      defaultValue: moment().add(1, 'months').format('MMM DD, YYYY HH:mm'),
     },
 
     // Links

--- a/packages/server/src/types.d.ts
+++ b/packages/server/src/types.d.ts
@@ -285,6 +285,7 @@ export namespace Layers {
       isAdmin?: boolean;
       agentId?: Models.AgentID;
       measuredByAgentId?: Models.AgentID;
+      measurableIds?: Models.MeasurementId[];
       transaction?: object;
       lock?: boolean;
       skipLocked?: boolean;


### PR DESCRIPTION
1. Change default resolution time to "1 month from now" on server and client.
2. Notebooks load all measurables referenced, as long as accessible.
3. Fixed bug where kde smoothing widths were 1 when max >> min, when min=0. This use case was not meant for cases where min=0.