### PR TITLE
Changed "G" to "B", and better display years

### DIFF
--- a/packages/components/src/Charts/cdfChartd3.js
+++ b/packages/components/src/Charts/cdfChartd3.js
@@ -83,12 +83,23 @@ function chart() {
     xAxis
       .ticks(5)
       .tickFormat(d => {
-        if (Math.abs(d) < 1) {
-          return d3.format(".2")(d);
-        } else {
-          return d3.formatPrefix(".0", d)(d);
-        }
+        	if(Math.abs(d)<1){
+            return(d3.format(".2")(d))
+
+          }else if(xMin>1000 && xMax<3000){
+            // Condition which identifies years; 2019, 2020,2021. 
+            return(d3.format(".0")(d))
+
+          }else{
+            var prefix = d3.formatPrefix(".0", d)
+            output = prefix(d)
+            output = output.replace("G","B")
+            return(output)
+          }
+
       });
+    
+    
 
     //Line generator
     var line = d3.line()

--- a/packages/components/src/Charts/cdfChartd3.js
+++ b/packages/components/src/Charts/cdfChartd3.js
@@ -83,23 +83,18 @@ function chart() {
     xAxis
       .ticks(5)
       .tickFormat(d => {
-        	if(Math.abs(d)<1){
-            return(d3.format(".2")(d))
-
-          }else if(xMin>1000 && xMax<3000){
+        	if (Math.abs(d)<1) {
+            return d3.format(".2")(d);
+          } else if (xMin>1000 && xMax<3000) {
             // Condition which identifies years; 2019, 2020,2021. 
-            return(d3.format(".0")(d))
-
-          }else{
-            var prefix = d3.formatPrefix(".0", d)
-            output = prefix(d)
-            output = output.replace("G","B")
-            return(output)
+            return d3.format(".0")(d);
+          } else {
+            var prefix = d3.formatPrefix(".0", d);
+            output = prefix(d);
+            output = output.replace("G","B");
+            return output;
           }
-
       });
-    
-    
 
     //Line generator
     var line = d3.line()


### PR DESCRIPTION
Changed 10G to 10B, (10 billions)
If the input is between 1000 and 3000, like, say, 2019, the number is rounded to the nearest integer. It would previously have been rounded to the nearest thousand. This could use some more tinkering.