### PR TITLE
Improve debouncer for nicer voting

### DIFF
--- a/packages/client/src/components/measurements/AgentVote.re
+++ b/packages/client/src/components/measurements/AgentVote.re
@@ -30,11 +30,13 @@ module MeasurementVotes = {
       });
 
     <>
-      <Antd.Button onClick={_ => modify(Down)} disabled={!canDecrement}>
+      <Antd.Button
+        size=`small onClick={_ => modify(Down)} disabled={!canDecrement}>
         {"<" |> Utils.ste}
       </Antd.Button>
       <span className=Styles.vote> {string_of_int(count) |> Utils.ste} </span>
-      <Antd.Button onClick={_ => modify(Up)} disabled={!canIncrement}>
+      <Antd.Button
+        size=`small onClick={_ => modify(Up)} disabled={!canIncrement}>
         {">" |> Utils.ste}
       </Antd.Button>
     </>;

--- a/packages/client/src/components/measurements/AgentVote.re
+++ b/packages/client/src/components/measurements/AgentVote.re
@@ -1,0 +1,74 @@
+module MeasurementVotes = {
+  type direction =
+    | Down
+    | Up;
+
+  module Styles = {
+    open Css;
+    let vote = style([marginLeft(`px(5)), marginRight(`px(5))]);
+  };
+
+  [@react.component]
+  let make = (~initialVoteCount, ~onUpdate) => {
+    let (count, setCount) = React.useState(() => initialVoteCount);
+    let canIncrement = count < 10;
+    let canDecrement = count > (-10);
+
+    let reducer = (d: direction) => {
+      switch (d) {
+      | Down when canDecrement => count - 1
+      | Up when canIncrement => count + 1
+      | _ => count
+      };
+    };
+
+    let modify = (d: direction) =>
+      setCount(_ => {
+        let newCount = reducer(d);
+        onUpdate(newCount);
+        newCount;
+      });
+
+    <>
+      <Antd.Button onClick={_ => modify(Down)} disabled={!canDecrement}>
+        {"<" |> Utils.ste}
+      </Antd.Button>
+      <span className=Styles.vote> {string_of_int(count) |> Utils.ste} </span>
+      <Antd.Button onClick={_ => modify(Up)} disabled={!canIncrement}>
+        {">" |> Utils.ste}
+      </Antd.Button>
+    </>;
+  };
+};
+
+// TODO: I think this would be cleaner if this module were a wrapper, similar to the <Mutation> used inside.
+// I wasn't sure how to do this though.
+module WithMutation = {
+  [@react.component]
+  let make = (~measurement: Types.measurement, ~initialVoteCount) => {
+    <MeasurementVote.Mutation>
+      ...{(mutation, result: MeasurementVote.Mutation.renderPropObj) => {
+        let send =
+          Debouncer.make(
+            ~wait=200,
+            MeasurementVote.mutate(mutation, measurement.id),
+          );
+
+        <MeasurementVotes initialVoteCount onUpdate=send />;
+      }}
+    </MeasurementVote.Mutation>;
+  };
+};
+
+[@react.component]
+let make = (~measurement: Types.measurement) => {
+  let can =
+    Primary.Permissions.can(`MEASUREMENT_VOTE, measurement.permissions);
+
+  let initialVoteCount =
+    measurement.vote
+    |> E.O.fmap((vote: Types.vote) => vote.voteAmount)
+    |> E.O.default(0);
+
+  can ? <WithMutation measurement initialVoteCount /> : <Null />;
+};

--- a/packages/client/src/components/measurements/MeasurementsTable.re
+++ b/packages/client/src/components/measurements/MeasurementsTable.re
@@ -271,9 +271,9 @@ let predictionText =
 let agentVote =
   Table.Column.make(
     ~name={
-      "Your Vote" |> Utils.ste;
+      "" |> Utils.ste;
     },
-    ~flex=3,
+    ~flex=2,
     ~render=(measurement: Types.measurement) => <AgentVote measurement />,
     (),
   );
@@ -283,7 +283,7 @@ let totalVotes =
     ~name={
       "Votes" |> Utils.ste;
     },
-    ~flex=2,
+    ~flex=1,
     ~render=
       (measurement: Types.measurement) => <Helpers.TotalVote measurement />,
     (),
@@ -415,16 +415,16 @@ let make =
         getPredictionDistribution(~bounds, ()),
         predictionValue,
         predictionText,
-        totalVotes,
         agentVote,
+        totalVotes,
         time,
       |]
     | (`none, `none, `PERCENTAGE) => [|
         agent,
         getPredictionDistribution(~bounds, ()),
         predictionValue,
-        totalVotes,
         agentVote,
+        totalVotes,
         time,
       |]
     | (`extended, `none, `FLOAT) => [|
@@ -434,8 +434,8 @@ let make =
         predictionText,
         logScore(),
         score(),
-        totalVotes,
         agentVote,
+        totalVotes,
         time,
       |]
     | (`extended, `none, `PERCENTAGE) => [|
@@ -444,24 +444,24 @@ let make =
         predictionValue,
         logScore(),
         score(),
-        totalVotes,
         agentVote,
+        totalVotes,
         time,
       |]
     | (`none, `inside, `FLOAT) => [|
         agent,
         getPredictionDistribution(~bounds, ~width=150, ()),
         predictionText,
-        totalVotes,
         agentVote,
+        totalVotes,
         time,
       |]
     | (`none, `inside, `PERCENTAGE) => [|
         agent,
         getPredictionDistribution(~bounds, ~width=150, ()),
         predictionValue,
-        totalVotes,
         agentVote,
+        totalVotes,
         time,
       |]
     | (`extended, `inside, `FLOAT) => [|
@@ -470,8 +470,8 @@ let make =
         predictionText,
         logScore(),
         score(),
-        totalVotes,
         agentVote,
+        totalVotes,
         time,
       |]
     | (`extended, `inside, `PERCENTAGE) => [|
@@ -479,8 +479,8 @@ let make =
         getPredictionDistribution(~bounds, ~width=150, ()),
         logScore(),
         score(),
-        totalVotes,
         agentVote,
+        totalVotes,
         time,
       |]
     | _ => Js.Exn.raiseError("Date not supported")

--- a/packages/client/src/components/measurements/MeasurementsTable.re
+++ b/packages/client/src/components/measurements/MeasurementsTable.re
@@ -120,81 +120,6 @@ module Helpers = {
       |> E.O.React.defaultNull;
   };
 
-  module MeasurementVote = {
-    [@react.component]
-    let make =
-        (
-          ~measurement: Types.measurement,
-          ~amount,
-          ~max,
-          ~currentVote,
-          ~children,
-        ) => {
-      <MeasurementVote.Mutation>
-        ...{(mutation, result: MeasurementVote.Mutation.renderPropObj) => {
-          let sum = ref(0);
-          let send =
-            Debouncer.make(
-              ~wait=200,
-              MeasurementVote.mutate(mutation, measurement.id),
-            );
-          let onClick = _ => {
-            sum := sum^ + amount;
-            sum := Pervasives.abs(sum^) > Pervasives.abs(max) ? max : sum^;
-            send(sum^);
-          };
-          let disabled = result.loading || max == currentVote;
-          <Antd.Button disabled onClick> children </Antd.Button>;
-        }}
-      </MeasurementVote.Mutation>;
-    };
-  };
-
-  module MeasurementVoteDown = {
-    [@react.component]
-    let make = (~measurement: Types.measurement, ~currentVote) => {
-      <MeasurementVote measurement amount=(-1) max=(-10) currentVote>
-        {"<" |> Utils.ste}
-      </MeasurementVote>;
-    };
-  };
-
-  module MeasurementVoteUp = {
-    [@react.component]
-    let make = (~measurement: Types.measurement, ~currentVote) => {
-      <MeasurementVote measurement amount=1 max=10 currentVote>
-        {">" |> Utils.ste}
-      </MeasurementVote>;
-    };
-  };
-
-  module AgentVote = {
-    module Styles = {
-      open Css;
-      let vote = style([marginLeft(`px(5)), marginRight(`px(5))]);
-    };
-    [@react.component]
-    let make = (~measurement: Types.measurement) => {
-      let can =
-        Primary.Permissions.can(`MEASUREMENT_VOTE, measurement.permissions);
-
-      let currentVote =
-        measurement.vote
-        |> E.O.fmap((vote: Types.vote) => vote.voteAmount)
-        |> E.O.default(0);
-
-      can
-        ? <>
-            <MeasurementVoteDown measurement currentVote />
-            <span className=Styles.vote>
-              {string_of_int(currentVote) |> Utils.ste}
-            </span>
-            <MeasurementVoteUp measurement currentVote />
-          </>
-        : <Null />;
-    };
-  };
-
   module TotalVote = {
     [@react.component]
     let make = (~measurement: Types.measurement) => {
@@ -349,8 +274,7 @@ let agentVote =
       "Your Vote" |> Utils.ste;
     },
     ~flex=3,
-    ~render=
-      (measurement: Types.measurement) => <Helpers.AgentVote measurement />,
+    ~render=(measurement: Types.measurement) => <AgentVote measurement />,
     (),
   );
 

--- a/packages/server/src/data/votes-data.js
+++ b/packages/server/src/data/votes-data.js
@@ -62,24 +62,16 @@ class VotesData extends DataBase {
     try {
       const vote = await this._voteLocked(agentId, measurementId, transaction);
 
-      let voteAmount = vote.voteAmount;
+      let voteAmountToUpdate = voteAmountInput;
 
-      if (voteAmountInput > 0 && voteAmount < 0) {
-        voteAmount = 0;
-      } else if (voteAmountInput < 0 && voteAmount > 0) {
-        voteAmount = 0;
+      if (voteAmountToUpdate < -10) {
+        voteAmountToUpdate = -10;
+      } else if (voteAmountToUpdate > 10) {
+        voteAmountToUpdate = 10;
       }
 
-      voteAmount += voteAmountInput;
-
-      if (voteAmount < -10) {
-        voteAmount = -10;
-      } else if (voteAmount > 10) {
-        voteAmount = 10;
-      }
-
-      if (voteAmount !== vote.voteAmount) {
-        await this._update(vote, voteAmount, transaction);
+      if (voteAmountToUpdate !== vote.voteAmount) {
+        await this._update(vote, voteAmountToUpdate, transaction);
       }
       await this.commit(transaction);
       return this._vote(agentId, measurementId, transaction);


### PR DESCRIPTION
We don't want users to have to wait for each vote for it to ping the server. This PR addresses that by separating the state of the vote widget from the backend server calls.