### PR TITLE
Make new bookmarked-communities section

### DIFF
--- a/packages/client/src/graphql/channels/ChannelBookmarkToogle.re
+++ b/packages/client/src/graphql/channels/ChannelBookmarkToogle.re
@@ -12,5 +12,6 @@ module Mutation = ReasonApollo.CreateMutation(Query);
 
 let mutate = (mutation: Mutation.apolloMutation, channelId) => {
   let m = Query.make(~channelId=E.J.fromString(channelId), ());
-  mutation(~variables=m##variables, ~refetchQueries=[||], ()) |> ignore;
+  mutation(~variables=m##variables, ~refetchQueries=[|"channels"|], ())
+  |> ignore;
 };


### PR DESCRIPTION
This makes a new section for "Bookmarked communities" in the header. 

It also changes the way these are refreshed, so that they can be toggled while keeping the header open.

![image](https://user-images.githubusercontent.com/377065/74282439-0b28d280-4d18-11ea-90d6-e6a46f82685d.png)
