### PR TITLE
Turns off this sync part

### DIFF
--- a/packages/client/src/App.re
+++ b/packages/client/src/App.re
@@ -12,7 +12,6 @@ module Main = {
              <Providers.AppContexProvider value>
                <Navigator />
                <Intercom />
-               <CheckSession />
              </Providers.AppContexProvider>;
            })
          )}


### PR DESCRIPTION
How authorization does work:
1. A user opens site as a guest. Nothing happens.
2. The user press "sign in/up" button and goes to Auth0.com site. Then the user is redirected back to the site.
3. The app sends a request to the server and passes "auth0Token" and "auth0jwt", gets back server JWT and stores this token to local storage. 
4. Each time the user opens the site again the application uses JWT from local storage and sends "checkSession" request to Auth0.com to get fresh "auth0Token" using some local auth0 data. Then the app sends refreshed token "auth0Token" back to the server. The server end needs this token to get personal info of users. 
5. When "some local auth0 data" expires then "checkSession" request falls. 

But right now I think that we do not need to send "checkSession" request since this token was gotten with the first authorization request to "auth0.com". The API of "auth0.com" are weak, so it is not obvious to me how to fix this in a more elegant way. I am going to keep eyes on it. 